### PR TITLE
Add superuser theme and Tiny-Webini versions

### DIFF
--- a/Themes/db.json
+++ b/Themes/db.json
@@ -282,6 +282,12 @@
 				{ "Name": "a4.9.6", "Date": "2020-12-16", "Link": "https://github.com/Tiny-Foxes/smtheme-soundwaves-community/archive/refs/tags/a4.9.6.tar.gz"},
 				{ "Name": "a4.9.5", "Date": "2020-11-30", "Link": "https://github.com/Tiny-Foxes/smtheme-soundwaves-community/archive/refs/tags/a4.9.5.tar.gz"}
 			]
+		},
+		"Superuser": {
+			"Name": "superuser",
+			"Date": "2021-07-05",
+			"Author": "Sudospective",
+			"Link": "https://github.com/Sudospective/superuser-outfox/archive/refs/tags/v1.0.0.zip"
 		}
 	}
 }

--- a/Tools/db.json
+++ b/Tools/db.json
@@ -354,6 +354,18 @@
                 "Date": "05-01-2021",
                 "Src": "Tiny-Webini-1.5-beta.tar.gz",
                 "Windows": "Tiny-Webini-1.5-bin.rar"
+            },
+            {
+                "Name": "Tiny-Webini-1.6",
+                "Date": "06-14-2021",
+                "Src": "Tiny-Webini-1.6-beta.tar.gz",
+                "Windows": "Tiny-Webini-1.6-bin.rar"
+            },
+            {
+                "Name": "Tiny-Webini-1.7",
+                "Date": "07-07-2021",
+                "Src": "Tiny-Webini-1.7-alpha.tar.gz",
+                "Windows": "Tiny-Webini-1.7-bin.rar"
             }
         ]
     }


### PR DESCRIPTION
This pull request adds: 

- The first version of the [Superuser](https://github.com/sudospective/superuser-outfox) theme by [Sudospective](https://github.com/Sudospective)
- [Tiny-Webini 1.6](https://github.com/Tiny-Foxes/Tiny-Webini/releases/tag/1.6-beta)
- [Tiny-Webini 1.7](https://github.com/Tiny-Foxes/Tiny-Webini/releases/tag/1.7-beta)